### PR TITLE
Don't update the AP SSID unless it has trailing zeros

### DIFF
--- a/bin/updateHostname
+++ b/bin/updateHostname
@@ -39,9 +39,15 @@ then
 	fi
 
 	hostname="$rootHostName-$m1$m2"
-	$(uci set wireless.@wifi-iface[0].ssid=$hostname)
 	$(uci set system.@system[0].hostname=$hostname)
 	$(uci set network.wwan.hostname=$hostname)
+
+	ssid=$(uci get wireless.@wifi-iface[0].ssid)
+	if echo "$ssid" | grep -qe "$nullHostName\$"; then
+		rootSsid=$(echo "$ssid" | sed -e 's/-....$//')
+		$(uci set wireless.@wifi-iface[0].ssid=$rootSsid-$m1$m2)
+	fi
+
 	$(uci commit)
 	$(/etc/init.d/system restart)
 	sleep 1


### PR DESCRIPTION
Took me a little while to figure out what was happening, but I was changing the AP ssid in the uci-defaults scripts and this was coming along and blowing away my change. Now it should only update the ssid if it has trailing zeros. It should behave the same as before in the case that both ssid and host id are "Omega-0000".

Here are some examples of the old behavior versus the new behavior. 

#### Old Undesired Behavior
**Input**: ssid=MySsid hostname=Omega-0000
**Output**: ssid=Omega-94A5 hostname=Omega-94A5

#### New Behavior Example 1
**Input**: ssid=MySsid hostname=Omega-0000
**Output**: ssid=MySsid hostname=Omega-94A5

#### New Behavior Example 2
**Input**: ssid=MySsid-0000 hostname=Omega-0000
**Output**:  ssid=MySsid-94A5 hostname=Omega-94A5

